### PR TITLE
feat(admin): add /admin/reset-key and /admin/reset-all-keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -490,13 +490,44 @@ func isProxyPath(path string) bool {
 }
 
 func (a *App) handleAdmin(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/admin/validate-keys" {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
+	switch {
+	case r.URL.Path == "/admin/validate-keys" && r.Method == http.MethodPost:
 		a.handleValidateKeys(w, r)
+	case r.URL.Path == "/admin/reset-key" && r.Method == http.MethodPost:
+		a.handleResetKey(w, r)
+	case r.URL.Path == "/admin/reset-all-keys" && r.Method == http.MethodPost:
+		a.handleResetAllKeys(w, r)
+	case r.URL.Path == "/admin/status" && r.Method == http.MethodGet:
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(a.keys.Status())
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleResetKey un-exhausts a single upstream key by index, without restarting
+// the proxy. Body: {"index": <int>}. Responds with the updated status.
+func (a *App) handleResetKey(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Index int `json:"index"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1024)).Decode(&body); err != nil {
+		http.Error(w, "invalid json body", http.StatusBadRequest)
 		return
+	}
+	if body.Index < 0 || body.Index >= len(a.config.UpstreamAPIKeys) {
+		http.Error(w, "index out of range", http.StatusBadRequest)
+		return
+	}
+	a.keys.MarkAvailable(body.Index)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(a.keys.Status())
+}
+
+// handleResetAllKeys un-exhausts every upstream key, without restarting.
+func (a *App) handleResetAllKeys(w http.ResponseWriter, r *http.Request) {
+	for i := range a.config.UpstreamAPIKeys {
+		a.keys.MarkAvailable(i)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(a.keys.Status())

--- a/main_test.go
+++ b/main_test.go
@@ -199,6 +199,65 @@ func TestAuthFailureReturnsOpenAIJSON(t *testing.T) {
 	}
 }
 
+func TestAdminResetKeyUnExhausts(t *testing.T) {
+	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"a", "b"}, UpstreamBaseURL: "http://example.com", MaxRequestBodyBytes: 1})
+	app.keys.MarkExhausted(0)
+	app.keys.MarkExhausted(1)
+	body := bytes.NewReader([]byte(`{"index":0}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/reset-key", body)
+	req.Header.Set("Authorization", "Bearer p")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d body %s", rec.Code, rec.Body.String())
+	}
+	var st StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Keys[0].State != string(KeyAvailable) {
+		t.Fatalf("key 0 not available: %+v", st.Keys[0])
+	}
+	if st.Keys[1].State != string(KeyExhausted) {
+		t.Fatalf("key 1 should still be exhausted: %+v", st.Keys[1])
+	}
+}
+
+func TestAdminResetKeyRejectsBadIndex(t *testing.T) {
+	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"a"}, UpstreamBaseURL: "http://example.com", MaxRequestBodyBytes: 1})
+	body := bytes.NewReader([]byte(`{"index":99}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/reset-key", body)
+	req.Header.Set("Authorization", "Bearer p")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", rec.Code)
+	}
+}
+
+func TestAdminResetAllKeys(t *testing.T) {
+	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"a", "b", "c"}, UpstreamBaseURL: "http://example.com", MaxRequestBodyBytes: 1})
+	for i := range app.config.UpstreamAPIKeys {
+		app.keys.MarkExhausted(i)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/admin/reset-all-keys", nil)
+	req.Header.Set("Authorization", "Bearer p")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d", rec.Code)
+	}
+	var st StatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	for i, k := range st.Keys {
+		if k.State != string(KeyAvailable) {
+			t.Fatalf("key %d not available: %+v", i, k)
+		}
+	}
+}
+
 func TestAuthFailureReturnsAnthropicJSON(t *testing.T) {
 	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"u"}, UpstreamBaseURL: "http://example.com", MaxRequestBodyBytes: 1})
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)


### PR DESCRIPTION
## Summary

When the proxy marks all upstream keys as exhausted, the process enters an unrecoverable state: every subsequent request returns 429 and the only way to recover is to restart the proxy, which loses in-memory state and drops in-flight connections. There is currently no admin path to un-exhaust a key without a process restart. This adds two authenticated admin endpoints so an operator (or an external monitor/automation) can recover from this state programmatically: `POST /admin/reset-key` (body `{"index": N}`) un-exhaustes a single key, and `POST /admin/reset-all-keys` un-exhaustes every key. Both are gated behind the existing `PROXY_API_KEY` admin auth, same as `/admin/status` and `/admin/validate-keys`.

The motivating failure mode is a false-positive exhaustion: a transient upstream error or a string-match drift in `isQuota429` causes the proxy to mark a healthy key as exhausted. Without these endpoints, the operator has no choice but to restart. With them, a cron job, healthcheck alert, or on-call runbook can call the endpoint and the proxy stays up.

## Why this is small

The `KeyManager.MarkAvailable` method already exists in `main.go` (line 398) and is already exercised by `handleValidateKeys` — it just had no operator-facing way to invoke it outside of validating every key. This PR wires that existing method into two new admin endpoints. There is no new state, no new state machine, and no new fields on `KeyManager`. The risk surface is limited to: the new admin routing, body parsing, and bounds checking on the index — all of which are covered by the new tests.

The `handleAdmin` dispatcher is also refactored from an `if`-chain into a `switch` on (path, method) so future admin endpoints are a one-line addition instead of a five-line nested branch.

## Changes

- `main.go`: rewrite `handleAdmin` as a `switch`; add `handleResetKey` and `handleResetAllKeys` handlers that call the existing `KeyManager.MarkAvailable` method.
- `main_test.go`: add `TestAdminResetKeyUnExhausts` (verifies one key resets while the other stays exhausted), `TestAdminResetKeyRejectsBadIndex` (out-of-range index returns 400), `TestAdminResetAllKeys` (verifies all keys reset at once).

## Behavior

- Correct API key required for both endpoints. Wrong/missing key returns 401 with the same JSON body as other admin endpoints.
- Reset is in-memory only; a process restart still resets all state, same as before.
- No logging of who reset what. If desired, that's a one-line `log.Printf` follow-up.

## Testing

`go test -count=1 -v ./...` — 26/26 PASS, including 3 new tests, no regressions.
