### PR TITLE
ci(docker): publish multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,30 +4,59 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
-
-permissions:
-  contents: read
-  packages: write
+      - "v*"
+  # allow manual trigger to rebuild/republish images (e.g. previous images were amd64-only)
+  workflow_dispatch:
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+
+    # scope permissions to this job only, least-privilege
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # enable emulation for non-native architectures (e.g. arm64 on amd64 runner)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # enable extended Buildx features (multi-platform builds, cache backends, etc.)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # authenticate against ghcr.io so we can push the image
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
+
+      # derive image tags + OCI labels from the git tag (e.g. v1.2.3 -> 1.2.3, 1.2, 1, latest)
+      - name: Extract metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/switchboard-go
-      - uses: docker/build-push-action@v6
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # build a multi-arch image and push it to ghcr.io, reusing GHA cache to speed up rebuilds
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Publish multi-arch container images (linux/amd64 + linux/arm64) to GHCR so Apple Silicon and other ARM64 hosts can run Switchboard without emulation or rebuilding locally.

The current workflow only builds a single-arch image, which is unusable on Apple Silicon / other ARM64 hosts.

## Changes

- Add QEMU + Buildx to build for `linux/amd64` and `linux/arm64`
- Add GHA cache (`mode=max`) to speed up subsequent builds
- Add `workflow_dispatch` to allow manually republishing older tags (e.g. for previously amd64-only releases)
- Scope `permissions` to the job (least-privilege)
- Derive image tags from semver (e.g. `v1.2.3` → `1.2.3`, `1.2`, `1`, `latest`)
- Use `${{ github.repository }}` instead of the hardcoded image name
- Add per-step comments explaining intent

## Test plan

- [ ] Push a `v*` tag and verify both `linux/amd64` and `linux/arm64` manifests are pushed to `ghcr.io/<owner>/switchboard-go`
- [ ] Pull and run on an amd64 host
- [ ] Pull and run on an arm64 host (e.g. Apple Silicon)
- [ ] Confirm GHA cache is populated and reused on the next run
- [ ] Trigger via `workflow_dispatch` and confirm it works without a new tag
