### PR TITLE
feat(keys): automatically retry exhausted keys after a cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ OpenAI/Anthropic-compatible app -> http://127.0.0.1:8080/v1 -> OpenCode Go
 - One proxy API key for your tools
 - Multiple upstream OpenCode Go keys behind the scenes
 - Automatic failover when an upstream key is exhausted
+- Automatic retry of exhausted keys after a configurable cooldown, so a
+  replenished account recovers without a restart or manual reset
 - Optional YAML config, Docker, admin status, and SMTP alerts
 
 ## Install
@@ -101,6 +103,7 @@ For opencode and Pi Coding Agent examples, see
 | `OPENCODE_GO_API_KEYS` | Yes | | Comma-separated upstream OpenCode Go API keys. |
 | `LISTEN_ADDR` | No | `:8080` | Use `127.0.0.1:8080` for local-only access. |
 | `UPSTREAM_BASE_URL` | No | `https://opencode.ai/zen/go/v1` | OpenCode Go upstream base URL. |
+| `RETRY_EXHAUSTED_AFTER` | No | `5m` | Cooldown before an exhausted key is retried automatically. `0` disables it. |
 
 YAML config is also supported. See
 [docs/configuration.md](docs/configuration.md).

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -28,14 +28,18 @@ Example response:
       "index": 0,
       "state": "exhausted",
       "last_429_time": "2026-06-19T11:48:29Z",
-      "current": false
+      "current": false,
+      "eligible": false,
+      "retry_after_seconds": 142
     },
     {
       "index": 1,
       "state": "available",
-      "current": true
+      "current": true,
+      "eligible": true
     }
   ],
+  "retry_exhausted_after_seconds": 300,
   "note": "Remaining usage is unavailable from opencode-go API."
 }
 ```
@@ -45,6 +49,20 @@ Key states are inferred by this proxy:
 - `unknown`: key has not yet been proven available or exhausted
 - `available`: key is currently selected and not marked exhausted
 - `exhausted`: key returned a quota/usage-exhausted `429`
+
+Additional fields:
+
+- `eligible`: whether the key may be handed out on the next request. An
+  exhausted key becomes eligible again once its cooldown elapses.
+- `retry_after_seconds`: remaining cooldown for an exhausted key that is not yet
+  eligible. Omitted for eligible keys and when the cooldown is disabled.
+- `retry_exhausted_after_seconds`: the configured cooldown before an exhausted
+  key is retried automatically. `0` means the cooldown is disabled.
+
+An exhausted key is retried automatically once its cooldown elapses; the next
+real request acts as the probe. See
+[Operations and security](operations.md) for details. The all-keys-exhausted
+`429` also carries a `Retry-After` header pointing at the next probe window.
 
 ## Validate keys
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,10 @@ upstream:
     - "sk-first"
     - "sk-second"
     - "sk-third"
+  # How long an exhausted key waits before it is retried automatically.
+  # Accepts a Go duration ("30s", "5m", "1h"). "0" disables the cooldown so
+  # exhausted keys are retried on the very next request.
+  retry_exhausted_after: "5m"
 
 smtp:
   host: "smtp.example.com"
@@ -77,6 +81,7 @@ limits:
 | `LISTEN_ADDR` | No | `:8080` | HTTP listen address. Use `127.0.0.1:8080` for local-only access. |
 | `UPSTREAM_BASE_URL` | No | `https://opencode.ai/zen/go/v1` | OpenCode Go upstream base URL for OpenAI-compatible and Anthropic Messages-compatible routes. |
 | `MAX_REQUEST_BODY_BYTES` | No | `20971520` | Maximum request body size. Requests above this return `413`. |
+| `RETRY_EXHAUSTED_AFTER` | No | `5m` | Cooldown before an exhausted key is retried automatically. Go duration (`30s`, `5m`). `0` disables the cooldown (retry on the next request). Maps to `upstream.retry_exhausted_after`. |
 | `SMTP_HOST` | No | | SMTP host for notifications. |
 | `SMTP_PORT` | No | `25` | SMTP port. |
 | `SMTP_USERNAME` | No | | SMTP username. If empty, SMTP AUTH is skipped. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,8 +24,29 @@ POST /messages            -> POST https://opencode.ai/zen/go/v1/messages
 
 When an upstream key returns a quota/usage-exhausted `429`, Switchboard Go marks
 that key as exhausted, sends a best-effort SMTP notification if configured, and
-retries the same request with the next non-exhausted key. If every key is
-exhausted, it returns an error shaped for the request style.
+retries the same request with the next eligible key. If every key is exhausted,
+it returns an error shaped for the request style.
+
+### Automatic retry of exhausted keys
+
+Exhausted keys do not stay exhausted forever. Each exhausted key becomes
+eligible for an automatic retry once `retry_exhausted_after` (default 5 minutes)
+has elapsed since its last quota `429`. The next real client request is the
+probe: it is forwarded with the eligible key. If the upstream account was
+replenished the request just succeeds and the key is marked available again; if
+it is still depleted, the key is re-marked exhausted and its cooldown restarts.
+The worst-case cost is one extra failed upstream round-trip per key per cooldown
+window - there is no background goroutine and no synthetic traffic.
+
+On any successful response the key is marked available and the notification
+flags re-arm, so a later depletion round alerts again instead of staying silent.
+
+While every key is within its cooldown, the proxy fast-fails locally with a
+`429` instead of hammering upstream, and includes a `Retry-After` header pointing
+at the next probe window so well-behaved clients (for example opencode, which
+honors `Retry-After`) pace themselves. Setting `retry_exhausted_after` to `0`
+disables the cooldown: exhausted keys are retried on the very next request and no
+`Retry-After` header is sent, leaving client backoff as the only pacing.
 
 ## Security notes
 
@@ -42,7 +63,8 @@ exhausted, it returns an error shaped for the request style.
 ## Operational behavior
 
 - Startup logs include listen address, upstream base URL, upstream key count,
-  SMTP configured yes/no, config source path, and max request body bytes.
+  SMTP configured yes/no, config source path, max request body bytes, and the
+  exhausted-key retry cooldown.
 - Request bodies larger than `max_request_body_bytes` are rejected with HTTP
   `413`.
 - Hop-by-hop and proxy headers are stripped when forwarding.
@@ -53,7 +75,8 @@ exhausted, it returns an error shaped for the request style.
   `x-api-key`.
 - If an upstream stream begins successfully and then later emits an error, the
   proxy does not recover mid-stream; it only retries before a response is sent.
-- Exhausted keys remain exhausted until the process restarts.
+- Exhausted keys are retried automatically once `retry_exhausted_after` has
+  elapsed (default 5 minutes); the admin API can still reset them immediately.
 
 ## Release artifacts
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -31,6 +32,11 @@ type Config struct {
 	ProxyAPIKey         string
 	UpstreamAPIKeys     []string
 	MaxRequestBodyBytes int64
+	// RetryExhaustedAfter is how long a key stays exhausted before it becomes
+	// eligible for an automatic retry probe. Zero disables the cooldown so
+	// exhausted keys are retried on the very next request (client backoff is the
+	// only pacing).
+	RetryExhaustedAfter time.Duration
 	ConfigSourcePath    string
 
 	SMTP SMTPConfig
@@ -71,7 +77,7 @@ func loadConfig() (Config, error) {
 }
 
 func defaultConfig() Config {
-	return Config{ListenAddr: ":8080", UpstreamBaseURL: "https://opencode.ai/zen/go/v1", MaxRequestBodyBytes: 20 << 20, SMTP: SMTPConfig{Port: 25}}
+	return Config{ListenAddr: ":8080", UpstreamBaseURL: "https://opencode.ai/zen/go/v1", MaxRequestBodyBytes: 20 << 20, RetryExhaustedAfter: 5 * time.Minute, SMTP: SMTPConfig{Port: 25}}
 }
 
 func resolveConfigPath() (string, bool, error) {
@@ -101,8 +107,9 @@ type yamlConfig struct {
 		ProxyAPIKey string `yaml:"proxy_api_key"`
 	} `yaml:"server"`
 	Upstream struct {
-		BaseURL string   `yaml:"base_url"`
-		APIKeys []string `yaml:"api_keys"`
+		BaseURL             string   `yaml:"base_url"`
+		APIKeys             []string `yaml:"api_keys"`
+		RetryExhaustedAfter string   `yaml:"retry_exhausted_after"`
 	} `yaml:"upstream"`
 	SMTP struct {
 		Host     string `yaml:"host"`
@@ -128,7 +135,20 @@ func loadYAMLConfig(path string) (Config, error) {
 	if err := yaml.Unmarshal(b, &yc); err != nil {
 		return Config{}, fmt.Errorf("parse config file: %w", err)
 	}
-	return Config{ListenAddr: yc.Server.ListenAddr, UpstreamBaseURL: yc.Upstream.BaseURL, ProxyAPIKey: yc.Server.ProxyAPIKey, UpstreamAPIKeys: yc.Upstream.APIKeys, MaxRequestBodyBytes: yc.Limits.MaxRequestBodyBytes, SMTP: SMTPConfig{Host: yc.SMTP.Host, Port: yc.SMTP.Port, Username: yc.SMTP.Username, Password: yc.SMTP.Password, From: yc.SMTP.From, To: yc.SMTP.To, TLS: yc.SMTP.TLS, StartTLS: yc.SMTP.StartTLS}}, nil
+	// -1 marks "not present in file" so mergeConfig can tell an explicit 0
+	// (disable cooldown) apart from an omitted value (keep the default).
+	retry := time.Duration(-1)
+	if s := strings.TrimSpace(yc.Upstream.RetryExhaustedAfter); s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse retry_exhausted_after: %w", err)
+		}
+		if d < 0 {
+			return Config{}, fmt.Errorf("retry_exhausted_after must be >= 0")
+		}
+		retry = d
+	}
+	return Config{ListenAddr: yc.Server.ListenAddr, UpstreamBaseURL: yc.Upstream.BaseURL, ProxyAPIKey: yc.Server.ProxyAPIKey, UpstreamAPIKeys: yc.Upstream.APIKeys, MaxRequestBodyBytes: yc.Limits.MaxRequestBodyBytes, RetryExhaustedAfter: retry, SMTP: SMTPConfig{Host: yc.SMTP.Host, Port: yc.SMTP.Port, Username: yc.SMTP.Username, Password: yc.SMTP.Password, From: yc.SMTP.From, To: yc.SMTP.To, TLS: yc.SMTP.TLS, StartTLS: yc.SMTP.StartTLS}}, nil
 }
 
 func mergeConfig(dst *Config, src Config) {
@@ -146,6 +166,9 @@ func mergeConfig(dst *Config, src Config) {
 	}
 	if src.MaxRequestBodyBytes > 0 {
 		dst.MaxRequestBodyBytes = src.MaxRequestBodyBytes
+	}
+	if src.RetryExhaustedAfter >= 0 {
+		dst.RetryExhaustedAfter = src.RetryExhaustedAfter
 	}
 	if src.SMTP.Host != "" {
 		dst.SMTP.Host = src.SMTP.Host
@@ -193,6 +216,11 @@ func applyEnvOverrides(cfg *Config) {
 	if v := strings.TrimSpace(os.Getenv("MAX_REQUEST_BODY_BYTES")); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			cfg.MaxRequestBodyBytes = n
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("RETRY_EXHAUSTED_AFTER")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			cfg.RetryExhaustedAfter = d
 		}
 	}
 	if v := os.Getenv("SMTP_HOST"); v != "" {
@@ -243,11 +271,14 @@ func validateConfig(cfg Config) error {
 	if cfg.MaxRequestBodyBytes <= 0 {
 		return errors.New("MAX_REQUEST_BODY_BYTES must be > 0")
 	}
+	if cfg.RetryExhaustedAfter < 0 {
+		return errors.New("RETRY_EXHAUSTED_AFTER must be >= 0")
+	}
 	return nil
 }
 
 func safeConfigSummary(cfg Config) string {
-	return fmt.Sprintf("listen=%s upstream=%s upstream_keys=%d smtp_configured=%t config_source=%s max_request_body_bytes=%d", cfg.ListenAddr, cfg.UpstreamBaseURL, len(cfg.UpstreamAPIKeys), cfg.SMTP.Host != "" && cfg.SMTP.From != "" && cfg.SMTP.To != "", defaultString(cfg.ConfigSourcePath, "none"), cfg.MaxRequestBodyBytes)
+	return fmt.Sprintf("listen=%s upstream=%s upstream_keys=%d smtp_configured=%t config_source=%s max_request_body_bytes=%d retry_exhausted_after=%s", cfg.ListenAddr, cfg.UpstreamBaseURL, len(cfg.UpstreamAPIKeys), cfg.SMTP.Host != "" && cfg.SMTP.From != "" && cfg.SMTP.To != "", defaultString(cfg.ConfigSourcePath, "none"), cfg.MaxRequestBodyBytes, cfg.RetryExhaustedAfter)
 }
 
 func parseBool(v string) bool { b, _ := strconv.ParseBool(strings.TrimSpace(v)); return b }
@@ -268,26 +299,47 @@ type KeyManager struct {
 	current        int
 	allNotified    bool
 	notifiedSwitch map[int]bool
+	// cooldown is how long an exhausted key waits before it becomes eligible for
+	// an automatic retry. Zero means exhausted keys are immediately eligible
+	// again (retry on the next request).
+	cooldown time.Duration
+	// now is injectable so tests can drive the cooldown with a fake clock.
+	now func() time.Time
 }
 
-func NewKeyManager(keys []string) *KeyManager {
+func NewKeyManager(keys []string, cooldown time.Duration) *KeyManager {
 	states := make([]KeyState, len(keys))
 	for i := range states {
 		states[i] = KeyUnknown
 	}
-	return &KeyManager{keys: append([]string(nil), keys...), states: states, last429: map[int]time.Time{}, notifiedSwitch: map[int]bool{}}
+	return &KeyManager{keys: append([]string(nil), keys...), states: states, last429: map[int]time.Time{}, notifiedSwitch: map[int]bool{}, cooldown: cooldown, now: func() time.Time { return time.Now().UTC() }}
+}
+
+// eligibleLocked reports whether key i may be handed out right now. A key that is
+// not exhausted is always eligible; an exhausted key becomes eligible again once
+// its cooldown has elapsed since the last quota error (so the next real request
+// acts as a probe).
+func (m *KeyManager) eligibleLocked(i int) bool {
+	if m.states[i] != KeyExhausted {
+		return true
+	}
+	t, ok := m.last429[i]
+	if !ok {
+		return true
+	}
+	return !m.now().Before(t.Add(m.cooldown))
 }
 
 func (m *KeyManager) Current() (int, string, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.keys) == 0 || m.allExhaustedLocked() {
+	if len(m.keys) == 0 {
 		return 0, "", false
 	}
-	if m.states[m.current] == KeyExhausted {
+	if !m.eligibleLocked(m.current) {
 		m.advanceLocked()
 	}
-	if m.states[m.current] == KeyExhausted {
+	if !m.eligibleLocked(m.current) {
 		return 0, "", false
 	}
 	return m.current, m.keys[m.current], true
@@ -300,7 +352,7 @@ func (m *KeyManager) MarkExhausted(i int) {
 		return
 	}
 	m.states[i] = KeyExhausted
-	m.last429[i] = time.Now().UTC()
+	m.last429[i] = m.now()
 	m.advanceLocked()
 }
 
@@ -344,12 +396,48 @@ func (m *KeyManager) advanceLocked() {
 	start := m.current
 	for step := 1; step <= len(m.keys); step++ {
 		next := (start + step) % len(m.keys)
-		if m.states[next] != KeyExhausted {
+		if m.eligibleLocked(next) {
 			m.current = next
 			return
 		}
 	}
 	m.current = start
+}
+
+// RetryAfterSeconds returns the number of seconds until the soonest exhausted key
+// becomes eligible for a retry, for use as a Retry-After header on the local
+// all-exhausted 429. The second return value is false when a Retry-After hint is
+// not meaningful: the cooldown is disabled, or some key is already usable.
+func (m *KeyManager) RetryAfterSeconds() (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cooldown <= 0 {
+		return 0, false
+	}
+	var soonest time.Time
+	found := false
+	for i := range m.keys {
+		if m.states[i] != KeyExhausted {
+			return 0, false
+		}
+		t, ok := m.last429[i]
+		if !ok {
+			return 0, false
+		}
+		eligibleAt := t.Add(m.cooldown)
+		if !found || eligibleAt.Before(soonest) {
+			soonest = eligibleAt
+			found = true
+		}
+	}
+	if !found {
+		return 0, false
+	}
+	secs := int(math.Ceil(soonest.Sub(m.now()).Seconds()))
+	if secs < 1 {
+		secs = 1
+	}
+	return secs, true
 }
 
 func (m *KeyManager) AllExhausted() bool {
@@ -373,12 +461,24 @@ func (m *KeyManager) Status() StatusResponse {
 	states := make([]PerKeyStatus, len(m.keys))
 	for i := range m.keys {
 		state := m.states[i]
+		display := state
 		if i == m.current && state != KeyExhausted {
-			state = KeyAvailable
+			display = KeyAvailable
 		}
-		states[i] = PerKeyStatus{Index: i, State: string(state), Last429Time: m.last429String(i), Current: i == m.current}
+		eligible := m.eligibleLocked(i)
+		ps := PerKeyStatus{Index: i, State: string(display), Last429Time: m.last429String(i), Current: i == m.current, Eligible: eligible}
+		if state == KeyExhausted && m.cooldown > 0 && !eligible {
+			if t, ok := m.last429[i]; ok {
+				secs := int(math.Ceil(t.Add(m.cooldown).Sub(m.now()).Seconds()))
+				if secs < 0 {
+					secs = 0
+				}
+				ps.RetryAfterSeconds = secs
+			}
+		}
+		states[i] = ps
 	}
-	return StatusResponse{CurrentKeyIndex: m.current, Keys: states, Note: "unknown means the key has not yet been validated or used since startup; remaining usage is unavailable from opencode-go API."}
+	return StatusResponse{CurrentKeyIndex: m.current, Keys: states, RetryExhaustedAfterSeconds: int(m.cooldown / time.Second), Note: "unknown means the key has not yet been validated or used since startup; an exhausted key becomes eligible for an automatic retry once retry_exhausted_after_seconds has elapsed since last_429_time (0 disables the cooldown); remaining usage is unavailable from opencode-go API."}
 }
 
 func (m *KeyManager) SetState(i int, state KeyState) {
@@ -389,11 +489,15 @@ func (m *KeyManager) SetState(i int, state KeyState) {
 	}
 	m.states[i] = state
 	if state == KeyExhausted {
-		m.last429[i] = time.Now().UTC()
+		m.last429[i] = m.now()
+		return
 	}
-	if state != KeyExhausted && m.current == i {
-		m.current = i
-	}
+	// Recovery: the key is usable again. Drop its cooldown timestamp and re-arm
+	// the notification flags so a future depletion round alerts again instead of
+	// staying silent.
+	delete(m.last429, i)
+	m.notifiedSwitch[i] = false
+	m.allNotified = false
 }
 
 func (m *KeyManager) MarkAvailable(i int) { m.SetState(i, KeyAvailable) }
@@ -410,11 +514,20 @@ type PerKeyStatus struct {
 	State       string `json:"state"`
 	Last429Time string `json:"last_429_time,omitempty"`
 	Current     bool   `json:"current"`
+	// Eligible reports whether the key may be handed out on the next request. An
+	// exhausted key is eligible again once its cooldown has elapsed.
+	Eligible bool `json:"eligible"`
+	// RetryAfterSeconds is the remaining cooldown for an exhausted key that is not
+	// yet eligible. Omitted for eligible keys and when the cooldown is disabled.
+	RetryAfterSeconds int `json:"retry_after_seconds,omitempty"`
 }
 type StatusResponse struct {
 	CurrentKeyIndex int            `json:"current_key_index"`
 	Keys            []PerKeyStatus `json:"keys"`
-	Note            string         `json:"note"`
+	// RetryExhaustedAfterSeconds is the configured cooldown before an exhausted
+	// key is retried automatically. Zero means the cooldown is disabled.
+	RetryExhaustedAfterSeconds int    `json:"retry_exhausted_after_seconds"`
+	Note                       string `json:"note"`
 }
 
 type ValidateKeyResult struct {
@@ -436,7 +549,7 @@ type App struct {
 }
 
 func newApp(cfg Config) *App {
-	return &App{config: cfg, keys: NewKeyManager(cfg.UpstreamAPIKeys), client: &http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment, DialContext: (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext, TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 30 * time.Second, ExpectContinueTimeout: 2 * time.Second}}, sender: NewSMTPNotifier(cfg.SMTP)}
+	return &App{config: cfg, keys: NewKeyManager(cfg.UpstreamAPIKeys, cfg.RetryExhaustedAfter), client: &http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment, DialContext: (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext, TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 30 * time.Second, ExpectContinueTimeout: 2 * time.Second}}, sender: NewSMTPNotifier(cfg.SMTP)}
 }
 
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -662,24 +775,24 @@ func (a *App) proxyV1(w http.ResponseWriter, r *http.Request, style APIStyle) {
 			if a.keys.ShouldNotifySwitch(idx) {
 				a.sender.NotifySwitch(idx, a.keys.Status())
 			}
-			if a.keys.ShouldNotifyAllExhausted() {
-				a.sender.NotifyAllExhausted(a.keys.Status())
-				writeAPIError(w, style, 429, "rate_limit_exceeded", "all upstream keys exhausted")
-				return
-			}
 			continue
 		}
+		// The key served the request, so it is healthy: mark it available so a
+		// recovered (previously exhausted) key un-sticks and the notification
+		// flags re-arm for the next depletion round.
+		a.keys.MarkAvailable(idx)
 		copyResponse(w, resp)
 		return
 	}
-	if a.keys.AllExhausted() {
-		if a.keys.ShouldNotifyAllExhausted() {
-			a.sender.NotifyAllExhausted(a.keys.Status())
-		}
-		writeAPIError(w, style, 429, "rate_limit_exceeded", "all upstream keys exhausted")
-		return
+	// No eligible key remains. Fail fast locally instead of hammering upstream,
+	// and hint well-behaved clients at the next probe window via Retry-After.
+	if a.keys.ShouldNotifyAllExhausted() {
+		a.sender.NotifyAllExhausted(a.keys.Status())
 	}
-	writeAPIError(w, style, 502, "bad_gateway", "upstream unavailable")
+	if secs, ok := a.keys.RetryAfterSeconds(); ok {
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+	}
+	writeAPIError(w, style, http.StatusTooManyRequests, "rate_limit_exceeded", "all upstream keys exhausted")
 }
 
 func (a *App) doUpstream(ctx context.Context, r *http.Request, body []byte, key string, apiStyle APIStyle) (*http.Response, error) {
@@ -930,7 +1043,7 @@ func main() {
 		defer cancel()
 		_ = srv.Shutdown(shut)
 	}()
-	log.Printf("startup listen_addr=%s upstream_base_url=%s upstream_keys=%d smtp_configured=%t config_source=%s max_request_body_bytes=%d", cfg.ListenAddr, cfg.UpstreamBaseURL, len(cfg.UpstreamAPIKeys), cfg.SMTP.Host != "" && cfg.SMTP.From != "" && cfg.SMTP.To != "", defaultString(cfg.ConfigSourcePath, "none"), cfg.MaxRequestBodyBytes)
+	log.Printf("startup listen_addr=%s upstream_base_url=%s upstream_keys=%d smtp_configured=%t config_source=%s max_request_body_bytes=%d retry_exhausted_after=%s", cfg.ListenAddr, cfg.UpstreamBaseURL, len(cfg.UpstreamAPIKeys), cfg.SMTP.Host != "" && cfg.SMTP.From != "" && cfg.SMTP.To != "", defaultString(cfg.ConfigSourcePath, "none"), cfg.MaxRequestBodyBytes, cfg.RetryExhaustedAfter)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestKeyManagerNoCurrentWhenExhausted(t *testing.T) {
-	km := NewKeyManager([]string{"a"})
+	km := NewKeyManager([]string{"a"}, time.Hour)
 	km.MarkExhausted(0)
 	if _, _, ok := km.Current(); ok {
 		t.Fatal("expected no current key")
@@ -455,5 +457,205 @@ upstream: {base_url: "https://yaml", api_keys: ["yaml1"]}
 	}
 	if cfg.ListenAddr != "0.0.0.0:9999" || cfg.ProxyAPIKey != "env" || len(cfg.UpstreamAPIKeys) != 2 || cfg.MaxRequestBodyBytes != 99 {
 		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}
+
+func TestKeyManagerRetryEligibleAfterCooldown(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	km := NewKeyManager([]string{"a"}, time.Minute)
+	km.now = func() time.Time { return now }
+	km.MarkExhausted(0)
+	if _, _, ok := km.Current(); ok {
+		t.Fatal("expected no eligible key immediately after exhaustion")
+	}
+	now = now.Add(59 * time.Second)
+	if _, _, ok := km.Current(); ok {
+		t.Fatal("expected key still in cooldown at 59s")
+	}
+	now = now.Add(2 * time.Second) // 61s since exhaustion
+	idx, key, ok := km.Current()
+	if !ok || idx != 0 || key != "a" {
+		t.Fatalf("expected key eligible after cooldown, got idx=%d key=%q ok=%v", idx, key, ok)
+	}
+}
+
+func TestKeyManagerZeroCooldownImmediatelyEligible(t *testing.T) {
+	km := NewKeyManager([]string{"a"}, 0)
+	km.MarkExhausted(0)
+	idx, key, ok := km.Current()
+	if !ok || idx != 0 || key != "a" {
+		t.Fatalf("expected exhausted key immediately eligible with zero cooldown, got ok=%v", ok)
+	}
+}
+
+func TestKeyManagerRetryAfterSeconds(t *testing.T) {
+	now := time.Unix(2000, 0).UTC()
+	km := NewKeyManager([]string{"a", "b"}, 2*time.Minute)
+	km.now = func() time.Time { return now }
+	km.MarkExhausted(0) // eligible at t=2120
+	now = now.Add(30 * time.Second)
+	km.MarkExhausted(1) // eligible at t=2150
+	secs, ok := km.RetryAfterSeconds()
+	if !ok || secs != 90 { // soonest 2120 - now 2030
+		t.Fatalf("expected retry-after 90s, got %d ok=%v", secs, ok)
+	}
+
+	km2 := NewKeyManager([]string{"a"}, 0)
+	km2.MarkExhausted(0)
+	if _, ok := km2.RetryAfterSeconds(); ok {
+		t.Fatal("expected no retry-after hint when cooldown is disabled")
+	}
+}
+
+func TestKeyManagerReArmsNotificationsOnRecovery(t *testing.T) {
+	km := NewKeyManager([]string{"a", "b"}, time.Minute)
+	km.MarkExhausted(0)
+	km.MarkExhausted(1)
+	if !km.ShouldNotifyAllExhausted() {
+		t.Fatal("expected first all-exhausted notification")
+	}
+	if km.ShouldNotifyAllExhausted() {
+		t.Fatal("expected all-exhausted notification suppressed the second time")
+	}
+	if !km.ShouldNotifySwitch(0) {
+		t.Fatal("expected switch notification for key 0")
+	}
+	// Recovery of a key must re-arm both the switch flag and the all-exhausted flag.
+	km.MarkAvailable(0)
+	if !km.ShouldNotifySwitch(0) {
+		t.Fatal("expected switch notification re-armed after recovery")
+	}
+	km.MarkExhausted(0)
+	if !km.ShouldNotifyAllExhausted() {
+		t.Fatal("expected all-exhausted notification re-armed after a recovery round")
+	}
+}
+
+func doProxyReq(app *App) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"glm-5.1","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer p")
+	rec := httptest.NewRecorder()
+	app.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestProxyRetriesExhaustedKeyAfterCooldown(t *testing.T) {
+	var replenished atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if replenished.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"quota exceeded","code":"insufficient_quota"}}`))
+	}))
+	defer upstream.Close()
+
+	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"k1"}, UpstreamBaseURL: upstream.URL, MaxRequestBodyBytes: 1024, RetryExhaustedAfter: time.Minute})
+	now := time.Unix(5000, 0).UTC()
+	app.keys.now = func() time.Time { return now }
+
+	// First request: the only key quota-fails, so the proxy returns a local 429
+	// carrying a Retry-After hint pointing at the next probe window.
+	rec := doProxyReq(app)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d body %s", rec.Code, rec.Body.String())
+	}
+	if ra := rec.Header().Get("Retry-After"); ra != "60" {
+		t.Fatalf("expected Retry-After 60, got %q", ra)
+	}
+
+	// Within the cooldown the proxy fast-fails without probing upstream again.
+	rec = doProxyReq(app)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 during cooldown, got %d", rec.Code)
+	}
+
+	// Cooldown elapses and the account is replenished: the next real request acts
+	// as a probe and succeeds.
+	now = now.Add(2 * time.Minute)
+	replenished.Store(true)
+	rec = doProxyReq(app)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 after cooldown+replenish, got %d body %s", rec.Code, rec.Body.String())
+	}
+	st := app.keys.Status()
+	if st.Keys[0].State != string(KeyAvailable) || !st.Keys[0].Eligible {
+		t.Fatalf("expected key available and eligible after recovery, got %+v", st.Keys[0])
+	}
+	if st.RetryExhaustedAfterSeconds != 60 {
+		t.Fatalf("expected retry_exhausted_after_seconds 60, got %d", st.RetryExhaustedAfterSeconds)
+	}
+}
+
+func TestProxyZeroCooldownNoRetryAfterHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"quota exceeded","code":"insufficient_quota"}}`))
+	}))
+	defer upstream.Close()
+
+	app := newApp(Config{ProxyAPIKey: "p", UpstreamAPIKeys: []string{"k1"}, UpstreamBaseURL: upstream.URL, MaxRequestBodyBytes: 1024, RetryExhaustedAfter: 0})
+	rec := doProxyReq(app)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	if ra := rec.Header().Get("Retry-After"); ra != "" {
+		t.Fatalf("expected no Retry-After header with cooldown disabled, got %q", ra)
+	}
+}
+
+func TestLoadConfigRetryExhaustedAfterParsedAndOverridden(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := []byte("server: {proxy_api_key: \"p\"}\nupstream: {base_url: \"https://x\", api_keys: [\"k\"], retry_exhausted_after: \"90s\"}\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SWITCHBOARD_GO_CONFIG", path)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RetryExhaustedAfter != 90*time.Second {
+		t.Fatalf("expected 90s from yaml, got %s", cfg.RetryExhaustedAfter)
+	}
+	t.Setenv("RETRY_EXHAUSTED_AFTER", "5m")
+	cfg, err = loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RetryExhaustedAfter != 5*time.Minute {
+		t.Fatalf("expected env override to 5m, got %s", cfg.RetryExhaustedAfter)
+	}
+}
+
+func TestLoadConfigRetryExhaustedAfterDefaultAndExplicitZero(t *testing.T) {
+	dir := t.TempDir()
+	omitted := filepath.Join(dir, "omitted.yaml")
+	if err := os.WriteFile(omitted, []byte("server: {proxy_api_key: \"p\"}\nupstream: {base_url: \"https://x\", api_keys: [\"k\"]}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SWITCHBOARD_GO_CONFIG", omitted)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RetryExhaustedAfter != 5*time.Minute {
+		t.Fatalf("expected default 5m when omitted, got %s", cfg.RetryExhaustedAfter)
+	}
+
+	zero := filepath.Join(dir, "zero.yaml")
+	if err := os.WriteFile(zero, []byte("server: {proxy_api_key: \"p\"}\nupstream: {base_url: \"https://x\", api_keys: [\"k\"], retry_exhausted_after: \"0\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SWITCHBOARD_GO_CONFIG", zero)
+	cfg, err = loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RetryExhaustedAfter != 0 {
+		t.Fatalf("expected explicit 0 to disable cooldown, got %s", cfg.RetryExhaustedAfter)
 	}
 }


### PR DESCRIPTION
Fixes #4.

## Problem

Once an upstream key is marked exhausted it is never un-marked automatically. When all keys are exhausted the proxy short-circuits every request with a local `429 all upstream keys exhausted` and never contacts upstream again, so replenishing an account has no effect until the operator manually resets the key or restarts the process. On top of that, the all-exhausted SMTP alert is sent once and never re-arms, and the local `429` carries no `Retry-After`.

## What this changes

Key eligibility becomes time-aware. An exhausted key becomes eligible for an automatic retry once a configurable cooldown has elapsed since its last quota `429`. The next real client request is the probe:

- If the account was replenished, the request just succeeds and the key is marked available again.
- If it is still depleted, the key is re-marked exhausted and its cooldown restarts.

There is no background goroutine and no synthetic traffic - the worst case is one extra failed upstream round-trip per key per cooldown window. The whole change is contained to `KeyManager` (time-aware eligibility), one line on `proxyV1`'s success path (mark the serving key healthy), and config plumbing for the cooldown.

### Details

- **Config:** `upstream.retry_exhausted_after` (YAML) / `RETRY_EXHAUSTED_AFTER` (env), a Go duration, default `5m`. `0` disables the cooldown so exhausted keys are retried on the very next request (client backoff is the only pacing) - this preserves today's fast-fail semantics for anyone who prefers them.
- **Notification re-arming:** on a genuine recovery (a successful response), the per-key switch flag and the all-exhausted flag reset, so a later depletion round alerts again instead of staying silent.
- **`Retry-After`:** the local all-exhausted `429` now carries a `Retry-After` header pointing at the next probe window, so clients that honor it (e.g. opencode) pace themselves exactly. Omitted when the cooldown is disabled.
- **Status:** `/admin/status` gains per-key `eligible` and `retry_after_seconds`, plus a top-level `retry_exhausted_after_seconds`.

### Why a per-key cooldown

Functionally the cooldown is not required for correctness (setting it to `0` is the pure "always try again" behavior). It is insurance against a client that hammers instead of backing off: without it, an endlessly-retrying client turns every retry into a fresh upstream probe with a full request-body re-upload. A single timestamp per key (already recorded today as `last429`) bounds that to one probe round per key per window, and keys recover independently with no separate round-state machine.

## Tests

`KeyManager` gets an injectable clock (`now func() time.Time`) so the cooldown is driven with a fake clock instead of real sleeps. Added coverage for cooldown expiry, zero-cooldown immediate eligibility, `Retry-After` computation, notification re-arming, an end-to-end exhaust -> cooldown -> replenish -> recover flow through `proxyV1` with an `httptest` upstream, and config parsing (default, explicit `0`, env override). `go vet ./...` and `go test -race ./...` pass.

## Docs

Updated `README.md`, `docs/configuration.md`, `docs/operations.md`, and `docs/admin-api.md` to describe the retry behavior, the new config knob, the `Retry-After` header, and the new status fields.
