### PR TITLE
fix(stream): fix LLM streaming (SSE) buffering by flushing chunks immediately

### DIFF
--- a/main.go
+++ b/main.go
@@ -785,7 +785,7 @@ func (a *App) proxyV1(w http.ResponseWriter, r *http.Request, style APIStyle) {
 		// recovered (previously exhausted) key un-sticks and the notification
 		// flags re-arm for the next depletion round.
 		a.keys.MarkAvailable(idx)
-		(w, resp)
+		copyResponse(w, resp)
 		return
 	}
 	// No eligible key remains. Fail fast locally instead of hammering upstream,

--- a/main.go
+++ b/main.go
@@ -886,7 +886,24 @@ func copyResponse(w http.ResponseWriter, resp *http.Response) {
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+
+	flusher, canFlush := w.(http.Flusher)
+
+	if canFlush && strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				w.Write(buf[:n])
+				flusher.Flush()
+			}
+			if err != nil {
+				break
+			}
+		}
+	} else {
+		_, _ = io.Copy(w, resp.Body)
+	}
 }
 
 func isQuota429(resp *http.Response) bool {

--- a/main.go
+++ b/main.go
@@ -785,7 +785,7 @@ func (a *App) proxyV1(w http.ResponseWriter, r *http.Request, style APIStyle) {
 		// recovered (previously exhausted) key un-sticks and the notification
 		// flags re-arm for the next depletion round.
 		a.keys.MarkAvailable(idx)
-		copyResponse(w, resp)
+		(w, resp)
 		return
 	}
 	// No eligible key remains. Fail fast locally instead of hammering upstream,
@@ -888,13 +888,14 @@ func copyResponse(w http.ResponseWriter, resp *http.Response) {
 	w.WriteHeader(resp.StatusCode)
 
 	flusher, canFlush := w.(http.Flusher)
+	isStream := strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream")
 
-	if canFlush && strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+	if canFlush && isStream {
 		buf := make([]byte, 4096)
 		for {
 			n, err := resp.Body.Read(buf)
 			if n > 0 {
-				w.Write(buf[:n])
+				_, _ = w.Write(buf[:n])
 				flusher.Flush()
 			}
 			if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -673,3 +673,92 @@ func TestLoadConfigRejectsInvalidRetryExhaustedAfterEnv(t *testing.T) {
 		t.Fatalf("expected RETRY_EXHAUSTED_AFTER validation error, got %v", err)
 	}
 }
+
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushCount int
+}
+
+func (f *flushRecorder) Flush() {
+	f.flushCount++
+	f.ResponseRecorder.Flush()
+}
+
+type chunkedReader struct {
+	chunks [][]byte
+	idx    int
+}
+
+func (cr *chunkedReader) Read(p []byte) (n int, err error) {
+	if cr.idx >= len(cr.chunks) {
+		return 0, io.EOF
+	}
+	n = copy(p, cr.chunks[cr.idx])
+	cr.idx++
+	return n, nil
+}
+
+func TestCopyResponseFlushesEventStream(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream; charset=utf-8"},
+		},
+		Body: io.NopCloser(&chunkedReader{
+			chunks: [][]byte{
+				[]byte("data: {\"choices\": [{\"delta\": {\"content\": \"Hello\"}}]}\n\n"),
+				[]byte("data: {\"choices\": [{\"delta\": {\"content\": \" World\"}}]}\n\n"),
+				[]byte("data: [DONE]\n\n"),
+			},
+		}),
+	}
+
+	copyResponse(rec, resp)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	if rec.flushCount != 3 {
+		t.Fatalf("expected exactly 3 flushes, got %d", rec.flushCount)
+	}
+
+	expectedBody := "data: {\"choices\": [{\"delta\": {\"content\": \"Hello\"}}]}\n\ndata: {\"choices\": [{\"delta\": {\"content\": \" World\"}}]}\n\ndata: [DONE]\n\n"
+	if rec.Body.String() != expectedBody {
+		t.Fatalf("unexpected body: got %q", rec.Body.String())
+	}
+}
+
+func TestCopyResponseDoesNotFlushNormalJSON(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(&chunkedReader{
+			chunks: [][]byte{
+				[]byte(`{"choices": `),
+				[]byte(`[{"message": {"content": "Hello World"}}]}`),
+			},
+		}),
+	}
+
+	copyResponse(rec, resp)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	if rec.flushCount != 0 {
+		t.Fatalf("expected 0 explicit flushes for non-stream JSON, got %d", rec.flushCount)
+	}
+
+	expectedBody := `{"choices": [{"message": {"content": "Hello World"}}]}`
+	if rec.Body.String() != expectedBody {
+		t.Fatalf("unexpected body: got %q", rec.Body.String())
+	}
+}


### PR DESCRIPTION
Currently, using io.Copy for proxying responses causes Go's http.ResponseWriter to buffer data (up to 4KB). This breaks the real-time UX for LLM streaming (stream: true), causing tokens to stall and appear in large, delayed chunks instead of smoothly typing out.

What it does:
- Detects text/event-stream content types.
- Explicitly calls http.Flusher.Flush() after every read to ensure zero-latency token delivery to the client.
- Keeps the standard io.Copy optimization for normal JSON responses.
- Adds unit tests with a mock http.Flusher to verify streaming and non-streaming behaviors.